### PR TITLE
Corrected spelling error in comments

### DIFF
--- a/src/doom/net.java
+++ b/src/doom/net.java
@@ -36,7 +36,7 @@ package doom;
 //
 // DESCRIPTION:
 //	DOOM Network game communication and protocol,
-//	all OS independend parts.
+//	all OS independent parts.
 //
 //-----------------------------------------------------------------------------
 


### PR DESCRIPTION
Change 'independend' to 'independent' in the comment above the class declaration.