### PR TITLE
Update ActionsThinkers.java

### DIFF
--- a/src/p/Actions/ActionsThinkers.java
+++ b/src/p/Actions/ActionsThinkers.java
@@ -295,7 +295,7 @@ public interface ActionsThinkers extends ActionsSectors, ThinkerList {
                 thinker.next.prev = thinker.prev;
                 thinker.prev.next = thinker.next;
                 // Z_Free (currentthinker);
-            } else {
+            } else if(thinker.thinkerFunction != null) {
                 if (thinker.thinkerFunction.isParamType(MobjConsumer.class)) {
                     thinker.thinkerFunction.fun(MobjConsumer.class).accept(DOOM().actions, (mobj_t) thinker);
                 } else if (thinker.thinkerFunction.isParamType(ThinkerConsumer.class)) {


### PR DESCRIPTION
This prevents a bug in some Doom Wads, most notably the IWAD for Doom2 throws a null pointer exception during the crusher, when the player walks on top of the active platform after the demons have been crushed.