### PR TITLE
Fix crusher null pointer exceptions

### DIFF
--- a/src/doom/thinker_t.java
+++ b/src/doom/thinker_t.java
@@ -6,6 +6,8 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import p.ActiveStates;
 import static utils.C2JUtils.pointer;
+
+import p.ThinkerStates;
 import w.CacheableDoomObject;
 import w.IPackableDoomObject;
 import w.IReadableDoomObject;
@@ -14,7 +16,7 @@ public class thinker_t implements CacheableDoomObject, IReadableDoomObject, IPac
 
     public thinker_t prev;
     public thinker_t next;
-    public ActiveStates thinkerFunction;
+    public ThinkerStates thinkerFunction = ActiveStates.NOP;
 
     /**
      * killough's code for thinkers seems to be totally broken in M.D,

--- a/src/p/Actions/ActionsCeilings.java
+++ b/src/p/Actions/ActionsCeilings.java
@@ -273,8 +273,6 @@ public interface ActionsCeilings extends ActionsMoveEvents, ActionsUseEvents {
                 && (activeCeilings[i].tag == line.tag)
                 && (activeCeilings[i].direction != 0)) {
                 activeCeilings[i].olddirection = activeCeilings[i].direction;
-                // MAES: don't set it to NOP here, otherwise its thinker will be
-                // removed and it won't be possible to restart it.
                 activeCeilings[i].thinkerFunction = ActiveStates.NOP;
                 activeCeilings[i].direction = 0;       // in-stasis
                 rtn = 1;

--- a/src/p/Actions/ActionsCeilings.java
+++ b/src/p/Actions/ActionsCeilings.java
@@ -275,7 +275,7 @@ public interface ActionsCeilings extends ActionsMoveEvents, ActionsUseEvents {
                 activeCeilings[i].olddirection = activeCeilings[i].direction;
                 // MAES: don't set it to NOP here, otherwise its thinker will be
                 // removed and it won't be possible to restart it.
-                activeCeilings[i].thinkerFunction = null;
+                activeCeilings[i].thinkerFunction = ActiveStates.NOP;
                 activeCeilings[i].direction = 0;       // in-stasis
                 rtn = 1;
             }

--- a/src/p/Actions/ActionsPlats.java
+++ b/src/p/Actions/ActionsPlats.java
@@ -29,6 +29,7 @@ import static m.fixed_t.FRACUNIT;
 import mochadoom.Engine;
 import mochadoom.Loggers;
 import p.AbstractLevelLoader;
+import static p.ActiveStates.NOP;
 import static p.ActiveStates.T_PlatRaise;
 import p.plat_e;
 import p.plat_t;
@@ -193,7 +194,7 @@ public interface ActionsPlats extends ActionsMoveEvents, ActionsUseEvents {
             if (activeplat != null && activeplat.status != plat_e.in_stasis && activeplat.tag == line.tag) {
                 activeplat.oldstatus = (activeplat).status;
                 activeplat.status = plat_e.in_stasis;
-                activeplat.thinkerFunction = null;
+                activeplat.thinkerFunction = NOP;
             }
         }
     }

--- a/src/p/Actions/ActiveStates/Ai.java
+++ b/src/p/Actions/ActiveStates/Ai.java
@@ -220,17 +220,15 @@ public interface Ai extends Monsters, Sounds {
         if (mobj.momx != 0 || mobj.momy != 0 || (eval(mobj.flags & MF_SKULLFLY))) {
             getAttacks().XYMovement(mobj);
 
-            // FIXME: decent NOP/NULL/Nil function pointer please.
-            if (mobj.thinkerFunction == ActiveStates.NOP) {
-                return; // mobj was removed
+            if (mobj.thinkerFunction.ordinal() == 0) {
+                return; // mobj was removed or nop
             }
         }
         if ((mobj.z != mobj.floorz) || mobj.momz != 0) {
             mobj.ZMovement();
 
-            // FIXME: decent NOP/NULL/Nil function pointer please.
-            if (mobj.thinkerFunction == ActiveStates.NOP) {
-                return; // mobj was removed
+            if (mobj.thinkerFunction.ordinal() == 0) {
+                return; // mobj was removed or nop
             }
         }
 

--- a/src/p/ActiveStates.java
+++ b/src/p/ActiveStates.java
@@ -85,7 +85,7 @@ import mochadoom.Loggers;
  * Or otherwise be sector specials, flickering lights etc.
  * Those are atypical and need special handling.
  */
-public enum ActiveStates {
+public enum ActiveStates implements ThinkerStates{
     NOP(ActiveStates::nop, ThinkerConsumer.class),
     A_Light0(ActionFunctions::A_Light0, PlayerSpriteConsumer.class),
     A_WeaponReady(ActionFunctions::A_WeaponReady, PlayerSpriteConsumer.class),
@@ -201,7 +201,7 @@ public enum ActiveStates {
     public interface PlayerSpriteConsumer extends ParamClass<PlayerSpriteConsumer> {
     	void accept(ActionFunctions a, player_t p, pspdef_t s);
     }
-    
+
     private interface ParamClass<T extends ParamClass<T>> {}
     
     public boolean isParamType(final Class<?> paramType) {

--- a/src/p/RemoveState.java
+++ b/src/p/RemoveState.java
@@ -1,0 +1,5 @@
+package p;
+
+public enum RemoveState implements ThinkerStates {
+    REMOVE;
+}

--- a/src/p/ThinkerStates.java
+++ b/src/p/ThinkerStates.java
@@ -1,0 +1,5 @@
+package p;
+
+public interface ThinkerStates {
+    int ordinal();
+}

--- a/src/savegame/VanillaDSG.java
+++ b/src/savegame/VanillaDSG.java
@@ -26,16 +26,11 @@ import java.util.logging.Level;
 import m.Settings;
 import mochadoom.Engine;
 import mochadoom.Loggers;
+import p.*;
 import p.Actions.ActionsLights.glow_t;
 import p.Actions.ActionsLights.lightflash_t;
 import static p.ActiveStates.*;
-import p.ThinkerList;
-import p.ceiling_t;
-import p.floormove_t;
-import p.mobj_t;
-import p.plat_t;
-import p.strobe_t;
-import p.vldoor_t;
+
 import rr.line_t;
 import rr.sector_t;
 import rr.side_t;
@@ -390,7 +385,7 @@ public class VanillaDSG<T, V> implements IDoomSaveGame {
 
         // save off the current thinkers
         for (th = DOOM.actions.getThinkerCap().next; th != DOOM.actions.getThinkerCap(); th = th.next) {
-            if (th.thinkerFunction != null && th.thinkerFunction == P_MobjThinker) {
+            if (th.thinkerFunction == P_MobjThinker) {
                 // Indicate valid thinker
                 fo.writeByte(thinkerclass_t.tc_mobj.ordinal());
                 // Pad...
@@ -594,7 +589,7 @@ public class VanillaDSG<T, V> implements IDoomSaveGame {
             buffer.position(0);
 
             // So ceilings don't think?
-            if (th.thinkerFunction == null) {
+            if (th.thinkerFunction == NOP) {
                 // i maintains status between iterations
                 for (i = 0; i < DOOM.actions.getMaxCeilings(); i++) {
                     if ((th instanceof ceiling_t) && (DOOM.actions.getActiveCeilings()[i] == (ceiling_t) th)) {


### PR DESCRIPTION
This fixes a bug in some Doom Wads, most notably the IWAD for Doom2 throws a null pointer exception during the crusher in MAP06, when the player walks on top of the active platform after the demons have been crushed.

This PR was supposed to fix the same problem too:
https://github.com/AXDOOMER/mochadoom/pull/20

But it it still crashed if you try to save the game afterwards, and generated a corrupted savegame.

This PR fixes both issues.