### PR TITLE
Fixed loading alternate configurations

### DIFF
--- a/classic.cfg
+++ b/classic.cfg
@@ -1,0 +1,43 @@
+mouse_sensitivity		5
+sfx_volume		8
+music_volume		8
+show_messages		1
+key_right		77
+key_left		75
+key_up		72
+key_down		80
+key_strafeleft		51
+key_straferight		52
+key_fire		29
+key_use		57
+key_strafe		56
+key_speed		54
+use_mouse		0
+mouseb_fire		0
+mouseb_strafe		1
+mouseb_forward		2
+use_joystick		0
+joyb_fire		0
+joyb_strafe		1
+joyb_use		3
+joyb_speed		2
+screenblocks		10
+detaillevel		0
+snd_channels		8
+snd_musicdevice		3
+snd_sfxdevice		3
+snd_sbport		0
+snd_sbirq		0
+snd_sbdma		0
+snd_mport		0
+usegamma		0
+chatmacro0		"No"
+chatmacro1		"I'm ready to kick butt!"
+chatmacro2		"I'm OK."
+chatmacro3		"I'm not looking too good!"
+chatmacro4		"Help!"
+chatmacro5		"You suck!"
+chatmacro6		"Next time, scumbag..."
+chatmacro7		"Come here!"
+chatmacro8		"I'll take care of it."
+chatmacro9		"Yes"

--- a/src/awt/EventBase.java
+++ b/src/awt/EventBase.java
@@ -60,6 +60,7 @@ public interface EventBase<Handler extends Enum<Handler> & EventBase<Handler>> e
     
     @SafeVarargs
     static <H extends Enum<H> & EventBase<H>> Relation<H>[] Relate(H src, H... dests) {
+        @SuppressWarnings("unchecked")
         final IntFunction<Relation<H>[]> arrayer = Relation[]::new;
         return Arrays.stream(dests)
             .map(dest -> new Relation<>(src, dest))
@@ -166,6 +167,7 @@ public interface EventBase<Handler extends Enum<Handler> & EventBase<Handler>> e
     final class KeyStateHolder<Handler extends Enum<Handler> & EventBase<Handler>> {
         private final Set<Signals.ScanCode> holdingSet;
         private final LinkedHashSet<KeyStateInterest<Handler>> keyInterests;
+        @SuppressWarnings("unchecked")
         private final IntFunction<KeyStateInterest<Handler>[]> generator = KeyStateInterest[]::new;
 
         public KeyStateHolder() {

--- a/src/doom/ConfigManager.java
+++ b/src/doom/ConfigManager.java
@@ -188,11 +188,17 @@ public class ConfigManager {
     
     public void SaveDefaults() {
         SETTINGS_MAP.forEach((file, settings) -> {
+            // skip writing settings which are not part of the loaded config files,
+            // this helps to not overwrite default.cfg with empty content in case we're using the -config argument
+            if (!this.configFiles.contains(file)) {
+                return;
+            }
+
             // do not write unless there is changes
             if (!file.changed) {
                 return;
             }
-            
+
             // choose existing config file or create one in current working directory
             final ResourceIO rio = file.firstValidPathIO().orElseGet(file::workDirIO);
             final Iterator<Settings> it = settings.stream().sorted(file.comparator).iterator();

--- a/src/doom/DoomMain.java
+++ b/src/doom/DoomMain.java
@@ -30,6 +30,7 @@ import static doom.gameaction_t.*;
 import f.EndLevel;
 import f.Finale;
 import f.Wiper;
+import g.Signals;
 import static g.Signals.ScanCode.*;
 import hu.HU;
 import i.DiskDrawer;
@@ -1289,21 +1290,7 @@ public class DoomMain<T, V> extends DoomStatus<T, V> implements IDoomGameNetwork
                 ev.withKey(sc -> {
                     gamekeydown[sc.ordinal()] = true;
                     if (vanillaKeyBehavior) {
-                        switch(sc) {
-                            case SC_LSHIFT:
-                            case SC_RSHIFT:
-                                gamekeydown[SC_RSHIFT.ordinal()] = gamekeydown[SC_LSHIFT.ordinal()] = true;
-                                break;
-                            case SC_LCTRL:
-                            case SC_RCTRL:
-                                gamekeydown[SC_RCTRL.ordinal()] = gamekeydown[SC_LCTRL.ordinal()] = true;
-                                break;
-                            case SC_LALT:
-                            case SC_RALT:
-                                gamekeydown[SC_RALT.ordinal()] = gamekeydown[SC_LALT.ordinal()] = true;
-                                break;
-                            default: break;
-                        }
+                        handleVanillaKeys(sc, true);
                     }
                 });
                 return true;    // eat key down events 
@@ -1318,21 +1305,7 @@ public class DoomMain<T, V> extends DoomStatus<T, V> implements IDoomGameNetwork
                 ev.withKey(sc -> {
                     gamekeydown[sc.ordinal()] = false;
                     if (vanillaKeyBehavior) {
-                        switch(sc) {
-                            case SC_LSHIFT:
-                            case SC_RSHIFT:
-                                gamekeydown[SC_RSHIFT.ordinal()] = gamekeydown[SC_LSHIFT.ordinal()] = false;
-                                break;
-                            case SC_LCTRL:
-                            case SC_RCTRL:
-                                gamekeydown[SC_RCTRL.ordinal()] = gamekeydown[SC_LCTRL.ordinal()] = false;
-                                break;
-                            case SC_LALT:
-                            case SC_RALT:
-                                gamekeydown[SC_RALT.ordinal()] = gamekeydown[SC_LALT.ordinal()] = false;
-                                break;
-                            default: break;
-                        }
+                        handleVanillaKeys(sc, false);
                     }
                 });
                 return false;   // always let key up events filter down 
@@ -1366,6 +1339,36 @@ public class DoomMain<T, V> extends DoomStatus<T, V> implements IDoomGameNetwork
         }
 
         return false;
+    }
+
+    private void handleVanillaKeys(Signals.ScanCode sc, boolean keyDown) {
+        switch(sc) {
+            case SC_LSHIFT:
+            case SC_RSHIFT:
+                gamekeydown[SC_RSHIFT.ordinal()] = gamekeydown[SC_LSHIFT.ordinal()] = keyDown;
+                break;
+            case SC_LCTRL:
+            case SC_RCTRL:
+                gamekeydown[SC_RCTRL.ordinal()] = gamekeydown[SC_LCTRL.ordinal()] = keyDown;
+                break;
+            case SC_LALT:
+            case SC_RALT:
+                gamekeydown[SC_RALT.ordinal()] = gamekeydown[SC_LALT.ordinal()] = keyDown;
+                break;
+            case SC_UP:
+                gamekeydown[SC_NUMKEY8.ordinal()] = keyDown;
+                break;
+            case SC_DOWN:
+                gamekeydown[SC_NUMKEY2.ordinal()] = keyDown;
+                break;
+            case SC_LEFT:
+                gamekeydown[SC_NUMKEY4.ordinal()] = keyDown;
+                break;
+            case SC_RIGHT:
+                gamekeydown[SC_NUMKEY6.ordinal()] = keyDown;
+                break;
+            default: break;
+        }
     }
 
     private final String turbomessage="is turbo!"; 

--- a/src/doom/DoomStatus.java
+++ b/src/doom/DoomStatus.java
@@ -390,8 +390,8 @@ public abstract class DoomStatus<T,V> {
     protected byte[] savebuffer;
 
     /* TODO Proper reconfigurable controls. Defaults hardcoded for now. T3h h4x, d00d. */
-    public int key_right = SC_NUMKEY6.ordinal();
-    public int key_left = SC_NUMKEY4.ordinal();
+    public int key_right = SC_RIGHT.ordinal();
+    public int key_left = SC_LEFT.ordinal();
     public int key_up = SC_W.ordinal();
     public int key_down = SC_S.ordinal();
     public int key_strafeleft = SC_A.ordinal();

--- a/src/mochadoom/Loggers.java
+++ b/src/mochadoom/Loggers.java
@@ -82,6 +82,7 @@ public class Loggers {
         
         lastHandler = handler;
         
+        @SuppressWarnings("unchecked")
         final IntFunction<EventBase<EventHandler>[]> arrayGenerator = EventBase[]::new;
         final EventBase<EventHandler>[] depends = actionStateHolder
                 .cooperations(handler, RelationType.DEPEND)

--- a/src/rr/SimpleTextureManager.java
+++ b/src/rr/SimpleTextureManager.java
@@ -239,7 +239,7 @@ public class SimpleTextureManager implements TextureManager<byte[]> {
         mtexture.unpack(maptex[texset]);
 
         // MAES: the HashTable only needs to know the correct names.
-        TextureCache.put(mtexture.name.toUpperCase(), new Integer(i));
+        TextureCache.put(mtexture.name.toUpperCase(), Integer.valueOf(i));
         
         // We don't need to manually copy trivial fields.
         textures[i]=new texture_t();

--- a/src/utils/C2JUtils.java
+++ b/src/utils/C2JUtils.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.Array;
+import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Arrays;
@@ -167,9 +168,9 @@ public final class C2JUtils {
     public static <T> void initArrayOfObjects(T[] os, Class<T> c) {
         try {
             for (int i = 0; i < os.length; i++) {
-                os[i] = c.newInstance();
+                os[i] = c.getDeclaredConstructor().newInstance();
             }
-        } catch (IllegalAccessException | InstantiationException e) {
+        } catch (IllegalAccessException | InstantiationException | NoSuchMethodException | InvocationTargetException e) {
             e.printStackTrace();
             System.err.println("Failure to allocate " + os.length
                     + " objects of class" + c.getName() + "!");
@@ -192,9 +193,9 @@ public final class C2JUtils {
         Class<T> c = (Class<T>) os.getClass().getComponentType();
         try {
             for (int i = 0; i < os.length; i++) {
-                os[i] = c.newInstance();
+                os[i] = c.getDeclaredConstructor().newInstance();
             }
-        } catch (IllegalAccessException | InstantiationException e) {
+        } catch (IllegalAccessException | InstantiationException | NoSuchMethodException | InvocationTargetException e) {
             e.printStackTrace();
             System.err.println("Failure to allocate " + os.length
                     + " objects of class " + c.getName() + "!");
@@ -229,9 +230,9 @@ public final class C2JUtils {
 
         try {
             for (int i = 0; i < os.length; i++) {
-                os[i] = c.newInstance();
+                os[i] = c.getDeclaredConstructor().newInstance();
             }
-        } catch (IllegalAccessException | InstantiationException e) {
+        } catch (IllegalAccessException | InstantiationException | NoSuchMethodException | InvocationTargetException e) {
             e.printStackTrace();
             System.err.println("Failure to instantiate " + os.length + " objects of class " + c.getName() + "!");
             System.exit(-1);
@@ -264,9 +265,9 @@ public final class C2JUtils {
 
         try {
             for (int i = 0; i < os.length; i++) {
-                os[i] = c.newInstance();
+                os[i] = c.getDeclaredConstructor().newInstance();
             }
-        } catch (IllegalAccessException | InstantiationException e) {
+        } catch (IllegalAccessException | InstantiationException | NoSuchMethodException | InvocationTargetException e) {
             e.printStackTrace();
             System.err.println("Failure to instantiate " + os.length
                     + " objects of class " + c.getName() + "!");
@@ -294,9 +295,9 @@ public final class C2JUtils {
 		Class<T> c = (Class<T>) os.getClass().getComponentType();
         try {
             for (int i = startpos; i < endpos; i++) {
-                os[i] = c.newInstance();
+                os[i] = c.getDeclaredConstructor().newInstance();
             }
-        } catch (IllegalAccessException | InstantiationException e) {
+        } catch (IllegalAccessException | InstantiationException | NoSuchMethodException | InvocationTargetException e) {
             e.printStackTrace();
             System.err.println("Failure to allocate " + os.length
                     + " objects of class " + c.getName() + "!");
@@ -708,9 +709,9 @@ public final class C2JUtils {
 
         T cls;
         try {
-            cls = (T) oldarray.getClass().getComponentType().newInstance();
+            cls = (T) oldarray.getClass().getComponentType().getDeclaredConstructor().newInstance();
             return resize(cls, oldarray, newsize);
-        } catch (IllegalAccessException | InstantiationException e) {
+        } catch (IllegalAccessException | InstantiationException | NoSuchMethodException | InvocationTargetException e) {
             System.err.println("Cannot autodetect type in resizeArray.\n");
             return null;
         }

--- a/src/w/DoomIO.java
+++ b/src/w/DoomIO.java
@@ -242,7 +242,7 @@ public class DoomIO  {
        Class<?> c=s.getClass().getComponentType();
        
        for (int i=0;i<Math.min(len,s.length);i++){
-           if (s[i]==null) s[i]=(IReadableDoomObject) c.newInstance();
+           if (s[i]==null) s[i]=(IReadableDoomObject) c.getDeclaredConstructor().newInstance();
            s[i].read(dis);
        }
    }
@@ -253,7 +253,7 @@ public class DoomIO  {
        
        for (int i=0;i<Math.min(len,s.length);i++){
            if (s[i]==null) {
-               s[i]=(IReadableDoomObject) c.newInstance();
+               s[i]=(IReadableDoomObject) c.getDeclaredConstructor().newInstance();
            }
            s[i].read(dis);
        }

--- a/src/w/WadLoader.java
+++ b/src/w/WadLoader.java
@@ -64,8 +64,11 @@ public class WadLoader implements IWadLoader {
         zone = new HashMap<>();
         wadfiles = new ArrayList<>();
         this.I = new DummySystem();
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            CloseAllHandles();
+        }));
     }
-	
 	
 	//// FIELDS
 
@@ -773,7 +776,7 @@ public class WadLoader implements IWadLoader {
 						// In case of sequential reads of similar objects, use 
 						// CacheLumpNumIntoArray instead.
 						thebuffer.rewind();
-						lumpcache[lump] = (CacheableDoomObject) what.newInstance();
+						lumpcache[lump] = (CacheableDoomObject) what.getDeclaredConstructor().newInstance();
 						lumpcache[lump].unpack(thebuffer);
 						
 						// Track it for freeing
@@ -1152,7 +1155,7 @@ public class WadLoader implements IWadLoader {
 		// in any chain, observing pwad ordering rules. killough
 
         for (int i = 0; i < numlumps; i++) { // hash function:
-            doomhash.put(lumpinfo[i].name.toUpperCase(), new Integer(i));
+            doomhash.put(lumpinfo[i].name.toUpperCase(), Integer.valueOf(i));
         }
     }
 
@@ -1235,10 +1238,11 @@ public class WadLoader implements IWadLoader {
 				
 	}
 	
-	@Override
-	public void finalize(){
-		CloseAllHandles();
-	}
+        // TODO: finalize is deprecated - CloseAllHandles() call is moved to shutdown hook
+	//@Override
+	//public void finalize(){
+	//	CloseAllHandles();
+	//}
 
 	public static final int ns_global=0;
 	public static final int ns_flats=1;


### PR DESCRIPTION
* Fix writing alternate config files i.e. when -config argument is used

  Previously the default.cfg is truncated to empty file in that case, and the alternate config file is not updated.

* Add classic Doom key controls configuration support (classic.cfg)

  Classic Doom key controls are using the arrow keys instead of WASD. Added mapping to arrow keys in vanilla key behavior mode.

* Fix/suppress some compile warnings, remove deprecated API usage

  Removed deprecated API calls to make sure Mocha Doom will compile with future Java versions.