### PR TITLE
Fix compilation error in java 21

### DIFF
--- a/src/w/IWadLoader.java
+++ b/src/w/IWadLoader.java
@@ -105,7 +105,7 @@ public interface IWadLoader {
      * @param <T>
      */
     @W_Wad.C(W_CacheLumpNum)
-    public abstract <T> T CacheLumpNum(int lump, int tag,
+    public abstract <T extends CacheableDoomObject> T CacheLumpNum(int lump, int tag,
         Class<T> what);
 
     // MAES 24/8/2011: superseded by auto-allocating version with proper 


### PR DESCRIPTION
Hey,
a little fix because it doesn't compile with Java 21.

the CacheLumpNum method of WadLoader do not compile in java 21 because of this line

`lumpcache[lump] = (CacheableDoomObject) thebuffer;`

thebuffer is a ByteBuffer which do not implements CacheableDoomObject.

An easy fix would have been 
`lumpcache[lump] = (CacheableDoomObject) (Object) thebuffer;`

but it would not solve the real issue which is that it can never happens as the 'what' parameter is always a class that implements CacheableDoomObject.
Also changed the case where it is called with a null parameter. In that case we want a DoomBuffer so let's pass it as argument.
